### PR TITLE
handle missing/empty data with specific message

### DIFF
--- a/source/Export.js
+++ b/source/Export.js
@@ -69,8 +69,13 @@ class Export {
   }
   
   downloadCsv(data) {
-  	try {
-    	console.info("Generating CSV download");
+    if(!data || !data.length)
+    {
+      alert('Unable to create export: no data provided. File would be empty.');
+      return;
+    }
+    try {
+      console.info("Generating CSV download");
       let blob = this._createCsvBlob(data);
       let filename = this._options.filename || "export.csv";
       this._download(blob, filename);


### PR DESCRIPTION
Right now, if no data is returned, _createCsvBlob() throws an error trying to loop through it, and an alert box pops up which says "Unable to create export: Cannot convert undefined or null to object". This is less than ideal--PR will detect this condition and alert with a descriptive message.