### PR TITLE
detect all endlines when quoting

### DIFF
--- a/source/Export.js
+++ b/source/Export.js
@@ -14,7 +14,7 @@ class CsvWriter {
 
   writeValue(value) {
     let stringValue = value === undefined ? "" : String(value);
-    let needsQuote = stringValue.indexOf(this._delimiter) !== -1 || /"\r\n/.test(stringValue);
+    let needsQuote = stringValue.indexOf(this._delimiter) !== -1 || /\r\n/.test(stringValue);
     this._currentRow.push(needsQuote ? this._quote(stringValue) : stringValue);
   }
 


### PR DESCRIPTION
Right now we aren't quoting endlines when they're not preceded by a single quote, which breaks CSV exports in certain scenarios (when the data contains non-quoted endlines). This PR fixes that.